### PR TITLE
chore: add build-test-push workflow

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -1,0 +1,72 @@
+name: build and test and push
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v20[0-9][0-9].[01][0-9].[0-3][0-9]  # e.g. v2023.12.04
+      - v20[0-9][0-9].[01][0-9].[0-3][0-9]-[0-9]  # e.g. v2023.12.04-2
+  pull_request:
+    branches:
+      - main
+
+env:
+  # This is a service-deploy-status service that's being used for the o11y-demo
+  # project. If we want to use this service for other demos, we'll need to
+  # rethink this part. Maybe push to a general GAR target and have all deploys
+  # for tenants trigger on that. Or maybe push to multiple GAR targets--one for
+  # each tenant.
+  IMAGE_NAME: service-deploy-status-web
+  GCP_PROJECT_ID: moz-fx-o11y-demo-prod
+  IMAGE_REPO_PATH: moz-fx-o11y-demo-prod/o11y-demo-prod/o11y-demo
+
+jobs:
+  build-test-push:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        run: sudo apt-get update && sudo apt-get install -y just
+      - name: Get info
+        run: |
+          uname -v
+          docker info
+          just version
+      - name: Create version.json
+        run: |
+          # create a version.json per
+          # https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+          "$GITHUB_SHA" \
+          "$GITHUB_REF_NAME" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
+      - name: Output version.json
+        run: cat version.json
+      - name: Build Docker image
+        run: just build
+      - name: Run linting in Docker image
+        run: just lint
+      - name: Run tests in Docker image
+        run: just test
+      - name: Set Docker image tag to sha for updates of the main branch
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo IMAGE_TAG=$(git rev-parse --short=10 "$GITHUB_SHA") >> "$GITHUB_ENV"
+      - name: Set Docker image tag to the git tag for tagged builds
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo IMAGE_TAG="$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+#       - name: Push Docker image to GAR
+#         if: env.IMAGE_TAG != ''
+#         uses: mozilla-it/deploy-actions/docker-push@v3.11.1
+#         with:
+#           local_image: ${{ env.IMAGE_NAME }}
+#           image_repo_path: ${{ env.IMAGE_REPO_PATH }}
+#           image_tag: ${{ env.IMAGE_TAG }}
+#           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+#           project_id: ${{ env.GCP_PROJECT_ID }}


### PR DESCRIPTION
This adds a build-test-push workflow that builds the Docker image, validates it, and then pushes it to GAR.

The "pushes it to GAR" part is commented out until we have settings in place.

This is what we have for mzcld-demo with some minor changes:

* this installs [just](https://just.systems/) because service-deploy-status uses just instead of make
* this moves the code for creating the `version.json` file to the workflow rather than in a separate script
* this adds a "get info" step for easier debugging in the future
