### PR TITLE
fix: create base template and add header to all pages

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{% block title %}TITLE{% endblock %}</title>
+  </head>
+  <body>
+<p>
+  [
+  <a href="{{ url_for('index_page') }}">Service Deploy Status</a> |
+  o11y demo |
+  <a href="https://github.com/mozilla/service-deploy-status">Source code</a> |
+  <a href="https://github.com/mozilla/service-deploy-status/issues">Issues</a>
+  ]
+</p>
+{% block body %}
+{% endblock %}
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,14 +1,10 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Service deploy status</title>
-  </head>
-  <body>
-    <h1>Service deploy status</h1>
-    <ul>
-      {% for system in systems %}
-        <li><a href="{{ url_for("system_page", system=system) }}">{{ system }}</a></li>
-      {% endfor %}
-    </ul>
-  </body>
-</html>
+{% extends "base.html" %}
+{% block title %}Service deploy status: Index{% endblock %}
+{% block body %}
+<h1>Service deploy status</h1>
+<ul>
+  {% for system in systems %}
+    <li><a href="{{ url_for("system_page", system=system) }}">{{ system }}</a></li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/app/templates/system.html
+++ b/app/templates/system.html
@@ -1,11 +1,6 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Service deploy status: {{ system }}</title>
-  </head>
-  <body>
-    <h1>System: {{ system }}</h1>
-    <pre>{{ output }}</pre>
-    <p><a href="{{ url_for('index_page') }}">Back to index</a></p>
-  </body>
-</html>
+{% extends "base.html" %}
+{% block title %}Service deploy status: {{ system }}{% endblock %}
+{% block body %}
+<h1>System: {{ system }}</h1>
+<pre>{{ output }}</pre>
+{% endblock %}


### PR DESCRIPTION
This reworks the templates to inherit from a base template.

This adds a header to all the pages with a link to the index page, link to the source code, and link to issue tracker.