### PR TITLE
fix: change APP_ENVIRONMENT default to "prod"

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -10,8 +10,9 @@ class Settings(BaseSettings):
     # Sets the opentelemetry collector endpoint
     APP_OTEL_COLLECTOR_ENDPOINT: str = "localhost:4317"
 
-    # "local", "stage", or "prod"
-    APP_ENVIRONMENT: str = "local"
+    # "local", "stage", or "prod"; defaults to "prod" because that's generally a safer
+    # default and less likely to reveal secrets
+    APP_ENVIRONMENT: str = "prod"
 
     # "INFO" or "WARNING"
     APP_LOGGING_LEVEL: str = "INFO"


### PR DESCRIPTION
"prod" is generally a safer default because it makes it less likely we divulge secrets in a server environment. In this particular app, it probably doesn't matter.