### PR TITLE
chore: improve shell recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,8 +17,8 @@ run: _env build
     docker compose up --watch web
 
 # Run a shell in the Docker web image
-shell: _env build
-    docker compose run --rm web shell
+shell *args: _env build
+    docker compose run --rm web shell {{args}}
 
 # Run tests
 test: _env build


### PR DESCRIPTION
This improves the shell recipe by allowing you to pass things to execute in the shell as arguments.

```
just shell python some_script.py
```