### PR TITLE
fix: add retry on service HTTP requests and add error handling

### DIFF
--- a/app/templates/system_error.html
+++ b/app/templates/system_error.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Service deploy status: {{ system }} -- error{% endblock %}
+{% block breadcrumbs %}
+  <nav class="py-1" aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item" aria-current="page">
+        <a href="{{ url_for('index_page') }}">Home</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        {{ system }}
+      </li>
+    </ol>
+  </nav>
+{% endblock %}
+{% block body %}
+<h1>System: {{ system }}</h1>
+<p>
+  Error: {{ msg }}
+</p>
+<p>
+  Depending on the error, please try again in a few minutes.
+</p>
+{% endblock %}


### PR DESCRIPTION
This adds retry for service version HTTP requests and adds error handling for when retrying fails. Now it'll show the error with an error page.